### PR TITLE
feat: redirect unauthenticated users to /login page with return URL

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,24 @@
+import { SignIn } from "@clerk/nextjs";
+
+export default function LoginPage({
+  searchParams,
+}: {
+  searchParams: { redirect_url?: string };
+}) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-zinc-50 px-4 dark:bg-black">
+      <div className="text-center">
+        <h1 className="text-2xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+          You need to log in to access this page
+        </h1>
+        <p className="mt-2 text-zinc-500 dark:text-zinc-400">
+          Sign in to continue to your destination.
+        </p>
+      </div>
+      <SignIn
+        forceRedirectUrl={searchParams.redirect_url ?? "/dashboard"}
+        routing="hash"
+      />
+    </div>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,13 +1,20 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
-const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)"]);
+const isPublicRoute = createRouteMatcher([
+  "/",
+  "/login(.*)",
+  "/sign-in(.*)",
+  "/sign-up(.*)",
+]);
 
 export default clerkMiddleware(async (auth, req) => {
   if (!isPublicRoute(req)) {
     const { userId } = await auth();
     if (!userId) {
-      return NextResponse.redirect(new URL("/", req.url));
+      const loginUrl = new URL("/login", req.url);
+      loginUrl.searchParams.set("redirect_url", req.nextUrl.pathname);
+      return NextResponse.redirect(loginUrl);
     }
   }
 });


### PR DESCRIPTION
Instead of redirecting to the home page, unauthenticated users trying to access /dashboard (or sub-routes) are now sent to /login?redirect_url=<path>. The new login page shows a "You need to log in" message and embeds Clerk's SignIn component, which redirects back to the original destination after a successful sign-in.